### PR TITLE
Verifier audits

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -113,7 +113,7 @@ public class Global : IDisposable
 
 				var coinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, RpcClient.Network, HttpClient);
 				var whitelist = await Whitelist.CreateAndLoadFromFileAsync(CoordinatorParameters.WhitelistFilePath, cancel).ConfigureAwait(false);
-				coinVerifier = new(CoinJoinIdStore, coinVerifierApiClient, whitelist, CoordinatorParameters.RuntimeCoordinatorConfig);
+				coinVerifier = new(CoinJoinIdStore, coinVerifierApiClient, whitelist, CoordinatorParameters.RuntimeCoordinatorConfig, Path.Combine(CoordinatorParameters.CoordinatorDataDir, "CoinVerifierAudits"));
 				Logger.LogInfo("CoinVerifier created successfully.");
 			}
 			catch (Exception exc)

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -113,7 +113,7 @@ public class Global : IDisposable
 
 				var coinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, RpcClient.Network, HttpClient);
 				var whitelist = await Whitelist.CreateAndLoadFromFileAsync(CoordinatorParameters.WhitelistFilePath, cancel).ConfigureAwait(false);
-				coinVerifier = new(CoinJoinIdStore, coinVerifierApiClient, whitelist, CoordinatorParameters.RuntimeCoordinatorConfig, Path.Combine(CoordinatorParameters.CoordinatorDataDir, "CoinVerifierAudits"));
+				coinVerifier = new(CoinJoinIdStore, coinVerifierApiClient, whitelist, CoordinatorParameters.RuntimeCoordinatorConfig, auditsDirectoryPath: Path.Combine(CoordinatorParameters.CoordinatorDataDir, "CoinVerifierAudits"));
 				Logger.LogInfo("CoinVerifier created successfully.");
 			}
 			catch (Exception exc)

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -682,7 +682,7 @@ public class CoordinatorRound
 		try
 		{
 			var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
-			await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
+			await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), possibleException, CancellationToken.None).ConfigureAwait(false);
 		}
 		catch (Exception ex)
 		{

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -29,7 +29,7 @@ public class CoordinatorRound
 	private RoundPhase _phase;
 	private CoordinatorRoundStatus _status;
 
-	public CoordinatorRound(IRPCClient rpc, UtxoReferee utxoReferee, CoordinatorRoundConfig config, int adjustedConfirmationTarget, int configuredConfirmationTarget, double configuredConfirmationTargetReductionRate, TimeSpan inputRegistrationTimeOut, CoinVerifier? coinVerifier = null, CoinVerifierAuditArchiver? auditArchiver = null)
+	public CoordinatorRound(IRPCClient rpc, UtxoReferee utxoReferee, CoordinatorRoundConfig config, int adjustedConfirmationTarget, int configuredConfirmationTarget, double configuredConfirmationTargetReductionRate, TimeSpan inputRegistrationTimeOut, CoinVerifier? coinVerifier = null)
 	{
 		try
 		{
@@ -40,7 +40,6 @@ public class CoordinatorRound
 			RoundConfig = Guard.NotNull(nameof(config), config);
 
 			CoinVerifier = coinVerifier;
-			CoinVerifierAuditArchiver = auditArchiver;
 			AdjustedConfirmationTarget = adjustedConfirmationTarget;
 			ConfiguredConfirmationTarget = configuredConfirmationTarget;
 			ConfiguredConfirmationTargetReductionRate = configuredConfirmationTargetReductionRate;
@@ -227,7 +226,6 @@ public class CoordinatorRound
 	public RoundNonceProvider NonceProvider { get; }
 
 	public static ConcurrentDictionary<(long roundId, RoundPhase phase), DateTimeOffset> PhaseTimeoutLog { get; } = new ConcurrentDictionary<(long roundId, RoundPhase phase), DateTimeOffset>();
-	public CoinVerifierAuditArchiver? CoinVerifierAuditArchiver { get; }
 
 	private void SetInputRegistrationTimesout()
 	{
@@ -682,11 +680,11 @@ public class CoordinatorRound
 
 		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
 
-		if (CoinVerifierAuditArchiver is not null)
+		if (CoinVerifier.CoinVerifierAuditArchiver is not null)
 		{
 			var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
 
-			await CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
+			await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
 		}
 	}
 

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -679,10 +679,15 @@ public class CoordinatorRound
 		}
 
 		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
-
-		var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
-
-		await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
+		try
+		{
+			var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
+			await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError("Something went wrong while saving audits.", ex);
+		}
 	}
 
 	private async Task MoveToInputRegistrationAsync()

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -680,12 +680,9 @@ public class CoordinatorRound
 
 		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
 
-		if (CoinVerifier.CoinVerifierAuditArchiver is not null)
-		{
-			var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
+		var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
 
-			await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
-		}
+		await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, Array.Empty<Coin>(), RoundId.ToString(), possibleException, CancellationToken.None).ConfigureAwait(false);
 	}
 
 	private async Task MoveToInputRegistrationAsync()

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -13,12 +13,13 @@ public record CoinVerifyInfo(bool ShouldBan, Coin Coin, ApiResponseItem? ApiResp
 
 public class CoinVerifier
 {
-	public CoinVerifier(CoinJoinIdStore coinJoinIdStore, CoinVerifierApiClient apiClient, Whitelist whitelist, WabiSabiConfig wabiSabiConfig)
+	public CoinVerifier(CoinJoinIdStore coinJoinIdStore, CoinVerifierApiClient apiClient, Whitelist whitelist, WabiSabiConfig wabiSabiConfig, CoinVerifierAuditArchiver coinVerifierAuditArchiver)
 	{
 		CoinJoinIdStore = coinJoinIdStore;
 		CoinVerifierApiClient = apiClient;
 		Whitelist = whitelist;
 		WabiSabiConfig = wabiSabiConfig;
+		CoinVerifierAuditArchiver = coinVerifierAuditArchiver;
 	}
 
 	// Blank constructor used for testing
@@ -32,6 +33,7 @@ public class CoinVerifier
 
 	public Whitelist Whitelist { get; }
 	public WabiSabiConfig WabiSabiConfig { get; }
+	public CoinVerifierAuditArchiver CoinVerifierAuditArchiver { get; }
 	private CoinJoinIdStore CoinJoinIdStore { get; }
 	private CoinVerifierApiClient CoinVerifierApiClient { get; }
 
@@ -40,6 +42,7 @@ public class CoinVerifier
 		// Step 1: Check if address is whitelisted.
 		if (Whitelist.TryGet(coin.Outpoint, out _))
 		{
+			CoinVerifierAuditArchiver.SaveAuditAsync()
 			return true;
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -14,12 +14,13 @@ public record CoinVerifyInfo(bool ShouldBan, Coin Coin, ApiResponseItem? ApiResp
 
 public class CoinVerifier
 {
-	public CoinVerifier(CoinJoinIdStore coinJoinIdStore, CoinVerifierApiClient apiClient, Whitelist whitelist, WabiSabiConfig wabiSabiConfig)
+	public CoinVerifier(CoinJoinIdStore coinJoinIdStore, CoinVerifierApiClient apiClient, Whitelist whitelist, WabiSabiConfig wabiSabiConfig, string archiverDirectoryPath)
 	{
 		CoinJoinIdStore = coinJoinIdStore;
 		CoinVerifierApiClient = apiClient;
 		Whitelist = whitelist;
 		WabiSabiConfig = wabiSabiConfig;
+		CoinVerifierAuditArchiver = new CoinVerifierAuditArchiver(archiverDirectoryPath);
 	}
 
 	// Blank constructor used for testing
@@ -33,6 +34,7 @@ public class CoinVerifier
 
 	public Whitelist Whitelist { get; }
 	public WabiSabiConfig WabiSabiConfig { get; }
+	public CoinVerifierAuditArchiver CoinVerifierAuditArchiver { get; }
 	private CoinJoinIdStore CoinJoinIdStore { get; }
 	private CoinVerifierApiClient CoinVerifierApiClient { get; }
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -9,7 +9,7 @@ using WalletWasabi.WabiSabi.Backend.Statistics;
 
 namespace WalletWasabi.WabiSabi.Backend.Banning;
 
-public record CoinVerifyInfo(bool ShouldBan, Coin Coin);
+public record CoinVerifyInfo(bool ShouldBan, Coin Coin, ApiResponseItem? ApiResponseItem);
 
 public class CoinVerifier
 {
@@ -70,7 +70,7 @@ public class CoinVerifier
 			if (CheckIfAlreadyVerified(coin))
 			{
 				innocentsCounter++;
-				yield return new CoinVerifyInfo(false, coin);
+				yield return new CoinVerifyInfo(false, coin, null);
 			}
 			else
 			{
@@ -91,7 +91,7 @@ public class CoinVerifier
 					Whitelist.Add(coin.Outpoint);
 				}
 
-				yield return new CoinVerifyInfo(shouldBanUtxo, coin);
+				yield return new CoinVerifyInfo(shouldBanUtxo, coin, response.ApiResponseItem);
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -53,9 +53,9 @@ public class CoinVerifierAuditArchiver
 		return ToLine(verifyInfo.Coin, verifyInfo.ShouldBan, verifyInfo.Reason.ToString(), roundId, details);
 	}
 
-	private string ToLine(Coin coin, bool isBanned, string reason, string roundId, string? details = null)
+	private string ToLine(Coin coin, bool isBanned, string reason, string roundId, string details = "None")
 	{
-		return $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff},{roundId},{coin.Outpoint},{coin.ScriptPubKey.GetDestinationAddress(Network.Main)},{isBanned},{coin.Amount},{reason},{details ?? "None"}";
+		return $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff},{roundId},{coin.Outpoint},{coin.ScriptPubKey.GetDestinationAddress(Network.Main)},{isBanned},{coin.Amount},{reason},{details}";
 	}
 
 	private async Task SaveToFileAsync(string fileContent, CancellationToken cancellationToken)
@@ -67,7 +67,7 @@ public class CoinVerifierAuditArchiver
 
 		using (await FileAsyncLock.LockAsync(cancellationToken))
 		{
-			await File.AppendAllLinesAsync(filePath, new[] { fileContent.ToString() }, cancellationToken).ConfigureAwait(false);
+			await File.AppendAllLinesAsync(filePath, new[] { fileContent }, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -21,7 +21,7 @@ public class CoinVerifierAuditArchiver
 
 	private AsyncLock FileAsyncLock { get; } = new();
 
-	public async Task SaveAuditAsync(List<CoinVerifyInfo> checkedCoins, IEnumerable<Coin> missingCoins, IEnumerable<Coin> zeroCoordFeePayingCoins, uint256 roundId, Exception? exception, CancellationToken cancellationToken)
+	public async Task SaveAuditAsync(List<CoinVerifyInfo> checkedCoins, IEnumerable<Coin> missingCoins, IEnumerable<Coin> zeroCoordFeePayingCoins, string roundId, Exception? exception, CancellationToken cancellationToken)
 	{
 		StringBuilder fileContent = new();
 
@@ -43,7 +43,7 @@ public class CoinVerifierAuditArchiver
 		await SaveToFileAsync(fileContent.ToString(), cancellationToken).ConfigureAwait(false);
 	}
 
-	private string ToLine(CoinVerifyInfo verifyInfo, uint256 roundId)
+	private string ToLine(CoinVerifyInfo verifyInfo, string roundId)
 	{
 		var ids = verifyInfo.ApiResponseItem?.Cscore_section.Cscore_info?.Select(x => x.Id);
 		var categories = verifyInfo.ApiResponseItem?.Cscore_section.Cscore_info.Select(x => x.Name);
@@ -53,7 +53,7 @@ public class CoinVerifierAuditArchiver
 		return ToLine(verifyInfo.Coin, verifyInfo.ShouldBan, verifyInfo.Reason.ToString(), roundId, details);
 	}
 
-	private string ToLine(Coin coin, bool isBanned, string reason, uint256 roundId, string? details = null)
+	private string ToLine(Coin coin, bool isBanned, string reason, string roundId, string? details = null)
 	{
 		return $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff},{roundId},{coin.Outpoint},{coin.ScriptPubKey.GetDestinationAddress(Network.Main)},{isBanned},{coin.Amount},{reason},{details ?? ""}";
 	}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -20,10 +20,10 @@ public class CoinVerifierAuditArchiver
 		var details = $"{string.Join(',', verifyInfo.ApiResponseItem.Cscore_section.Cscore_info.Select(x => x.Id).ToArray())};" +
 			$"{string.Join(',', verifyInfo.ApiResponseItem.Cscore_section.Cscore_info.Select(x => x.Name))}";
 
-		await SaveAuditAsync(verifyInfo.Coin, verifyInfo.ShouldBan, Reason.RemoteApi, details).ConfigureAwait(false);
+		await SaveAuditAsync(verifyInfo.Coin, verifyInfo.ShouldBan, verifyInfo.Reason.ToString(), details).ConfigureAwait(false);
 	}
 
-	public async Task SaveAuditAsync(Coin coin, bool isBanned, Reason reason, string? details)
+	public async Task SaveAuditAsync(Coin coin, bool isBanned, string reason, string? details = null)
 	{
 		var currentDate = DateTimeOffset.UtcNow;
 
@@ -31,13 +31,6 @@ public class CoinVerifierAuditArchiver
 		string filePath = Path.Combine(BaseDirectoryPath, fileName);
 		IoHelpers.EnsureDirectoryExists(BaseDirectoryPath);
 
-		await File.AppendAllLinesAsync(filePath, new[] { $"{coin.Outpoint}:{coin.ScriptPubKey.GetDestinationAddress(Network.Main)}:{coin.Amount}:{reason}:{details}" }).ConfigureAwait(false);
+		await File.AppendAllLinesAsync(filePath, new[] { $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff}:{coin.Outpoint}:{coin.ScriptPubKey.GetDestinationAddress(Network.Main)}:{isBanned}:{coin.Amount}:{reason}:{details ?? ""}" }).ConfigureAwait(false);
 	}
-}
-
-public enum Reason
-{
-	WhiteList,
-	RemoteApi,
-	Coinjoin
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -55,7 +55,7 @@ public class CoinVerifierAuditArchiver
 
 	private string ToLine(Coin coin, bool isBanned, string reason, string roundId, string? details = null)
 	{
-		return $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff},{roundId},{coin.Outpoint},{coin.ScriptPubKey.GetDestinationAddress(Network.Main)},{isBanned},{coin.Amount},{reason},{details ?? ""}";
+		return $"{DateTimeOffset.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff},{roundId},{coin.Outpoint},{coin.ScriptPubKey.GetDestinationAddress(Network.Main)},{isBanned},{coin.Amount},{reason},{details ?? "None"}";
 	}
 
 	private async Task SaveToFileAsync(string fileContent, CancellationToken cancellationToken)

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -1,0 +1,61 @@
+using NBitcoin;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.WabiSabi.Backend.Banning;
+
+public class CoinVerifierAuditArchiver
+{
+	public CoinVerifierAuditArchiver(string directoryPath)
+	{
+		BaseDirectoryPath = directoryPath;
+	}
+
+	public string BaseDirectoryPath { get; }
+
+	public async Task<string> SaveAuditAsync(CoinVerifyInfo verifyInfo)
+	{
+		var currentDate = DateTimeOffset.UtcNow;
+
+		VerifierAudit audit = new(
+			verifyInfo.Coin.Outpoint,
+			verifyInfo.Coin.ScriptPubKey.GetDestinationAddress(Network.Main),
+			verifyInfo.Coin.Amount,
+			verifyInfo.ApiResponseItem.Cscore_section.Cscore_info.First().Name,
+			verifyInfo.ApiResponseItem.Cscore_section.Cscore_info.Select(x => x.Id).ToArray()
+			);
+
+		// Use a date format in the file name to let the files be sorted by date by default.
+		string fileName = $"VerifierAudits.{currentDate:yyyy.MM}.txt";
+		string filePath = Path.Combine(BaseDirectoryPath, fileName);
+		IoHelpers.EnsureDirectoryExists(BaseDirectoryPath);
+
+		await File.AppendAllLinesAsync(filePath, new[] { audit.ToLine() }).ConfigureAwait(false);
+
+		return filePath;
+	}
+}
+
+public class VerifierAudit
+{
+	public VerifierAudit(OutPoint outPoint, BitcoinAddress address, Money amount, string riskCategory, int[] riskFlagIds)
+	{
+		OutPoint = outPoint;
+		Address = address;
+		Amount = amount;
+		RiskCategory = riskCategory;
+		RiskFlagIds = riskFlagIds;
+	}
+
+	public OutPoint OutPoint { get; }
+	public BitcoinAddress Address { get; }
+	public Money Amount { get; }
+	public string RiskCategory { get; }
+	public int[] RiskFlagIds { get; }
+
+	public string ToLine()
+	{
+		return $"{OutPoint}:{Address}:{Amount}:{RiskCategory}:{RiskFlagIds}";
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierAuditArchiver.cs
@@ -45,10 +45,11 @@ public class CoinVerifierAuditArchiver
 
 	private string ToLine(CoinVerifyInfo verifyInfo, string roundId)
 	{
+		var reportId = verifyInfo.ApiResponseItem?.Report_info_section.Report_id;
 		var ids = verifyInfo.ApiResponseItem?.Cscore_section.Cscore_info?.Select(x => x.Id);
 		var categories = verifyInfo.ApiResponseItem?.Cscore_section.Cscore_info.Select(x => x.Name);
 
-		var details = $"{(ids is null ? "None" : string.Join(',', ids))}:{(categories is null ? "None" : string.Join(',', categories))}";
+		var details = $"{reportId ?? "ReportID None"}:{(ids is null ? "None" : string.Join(',', ids))}:{(categories is null ? "None" : string.Join(',', categories))}";
 
 		return ToLine(verifyInfo.Coin, verifyInfo.ShouldBan, verifyInfo.Reason.ToString(), roundId, details);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -154,7 +154,7 @@ public partial class Arena : PeriodicRunner
 						var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
 						var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
 
-						await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
+						await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, possibleException, cancel).ConfigureAwait(false);
 					}
 					catch (Exception ex)
 					{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -149,10 +149,17 @@ public partial class Arena : PeriodicRunner
 						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}).", exc);
 					}
 
-					var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
-					var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
+					try
+					{
+						var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
+						var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
 
-					await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
+						await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError("Something went wrong while saving audits.", ex);
+					}
 				}
 
 				if (round.InputCount < Config.MinInputCountByRound)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -149,13 +149,10 @@ public partial class Arena : PeriodicRunner
 						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}).", exc);
 					}
 
-					if (CoinVerifier.CoinVerifierAuditArchiver is not null)
-					{
-						var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
-						var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
+					var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
+					var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
 
-						await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
-					}
+					await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
 				}
 
 				if (round.InputCount < Config.MinInputCountByRound)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -151,15 +151,13 @@ public partial class Arena : PeriodicRunner
 						possibleException = exc;
 						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}).", exc);
 					}
-					finally
-					{
-						if (CoinVerifierAuditArchiver is not null)
-						{
-							var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
-							var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
 
-							await CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id, possibleException, cancel).ConfigureAwait(false);
-						}
+					if (CoinVerifierAuditArchiver is not null)
+					{
+						var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
+						var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
+
+						await CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
 					}
 				}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -33,8 +33,7 @@ public partial class Arena : PeriodicRunner
 		RoundParameterFactory roundParameterFactory,
 		CoinJoinTransactionArchiver? archiver = null,
 		CoinJoinScriptStore? coinJoinScriptStore = null,
-		CoinVerifier? coinVerifier = null,
-		CoinVerifierAuditArchiver? coinVerifierAuditArchiver = null) : base(period)
+		CoinVerifier? coinVerifier = null) : base(period)
 	{
 		Config = config;
 		Rpc = rpc;
@@ -45,7 +44,6 @@ public partial class Arena : PeriodicRunner
 		RoundParameterFactory = roundParameterFactory;
 		CoinVerifier = coinVerifier;
 		MaxSuggestedAmountProvider = new(Config);
-		CoinVerifierAuditArchiver = coinVerifierAuditArchiver;
 	}
 
 	public event EventHandler<Transaction>? CoinJoinBroadcast;
@@ -62,7 +60,6 @@ public partial class Arena : PeriodicRunner
 	private ICoinJoinIdStore CoinJoinIdStore { get; set; }
 	private RoundParameterFactory RoundParameterFactory { get; }
 	public MaxSuggestedAmountProvider MaxSuggestedAmountProvider { get; }
-	public CoinVerifierAuditArchiver? CoinVerifierAuditArchiver { get; }
 
 	protected override async Task ActionAsync(CancellationToken cancel)
 	{
@@ -152,12 +149,12 @@ public partial class Arena : PeriodicRunner
 						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}).", exc);
 					}
 
-					if (CoinVerifierAuditArchiver is not null)
+					if (CoinVerifier.CoinVerifierAuditArchiver is not null)
 					{
 						var failedToCheckCoins = coinsToCheck.Except(successfullyCheckedCoins.Select(x => x.Coin));
 						var zeroCoordFeePayingCoins = round.Alices.Where(x => x.IsPayingZeroCoordinationFee).Select(x => x.Coin);
 
-						await CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
+						await CoinVerifier.CoinVerifierAuditArchiver.SaveAuditAsync(successfullyCheckedCoins, failedToCheckCoins, zeroCoordFeePayingCoins, round.Id.ToString(), possibleException, cancel).ConfigureAwait(false);
 					}
 				}
 

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -32,8 +32,6 @@ public class WabiSabiCoordinator : BackgroundService
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinFeeRateStatStoreFilePath);
 		CoinJoinFeeRateStatStore.NewStat += FeeRateStatStore_NewStat;
 
-		CoinVerifierAuditArchiver auditArchiver = new(Path.Combine(parameters.CoordinatorDataDir, "CoinVerifierAudits"));
-
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinScriptStoreFilePath);
 
 		RoundParameterFactory roundParameterFactory = new(Config, rpc.Network);
@@ -46,8 +44,7 @@ public class WabiSabiCoordinator : BackgroundService
 			roundParameterFactory,
 			transactionArchiver,
 			coinJoinScriptStore,
-			coinVerifier,
-			auditArchiver);
+			coinVerifier);
 
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinIdStoreFilePath);
 		Arena.CoinJoinBroadcast += Arena_CoinJoinBroadcast;

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -32,6 +32,8 @@ public class WabiSabiCoordinator : BackgroundService
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinFeeRateStatStoreFilePath);
 		CoinJoinFeeRateStatStore.NewStat += FeeRateStatStore_NewStat;
 
+		CoinVerifierAuditArchiver auditArchiver = new(Path.Combine(parameters.CoordinatorDataDir, "CoinVerifierAudits"));
+
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinScriptStoreFilePath);
 
 		RoundParameterFactory roundParameterFactory = new(Config, rpc.Network);
@@ -44,7 +46,8 @@ public class WabiSabiCoordinator : BackgroundService
 			roundParameterFactory,
 			transactionArchiver,
 			coinJoinScriptStore,
-			coinVerifier);
+			coinVerifier,
+			auditArchiver);
 
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinIdStoreFilePath);
 		Arena.CoinJoinBroadcast += Arena_CoinJoinBroadcast;


### PR DESCRIPTION
PR about saving audits on server side, why did we let that coin in, etc etc

The file will be saved to `.walletwasabi\Backend\WabiSabi\CoinVerifierAudits`

File name `VerifierAudits.2023.01.txt` , so every month will have their own file.

![image](https://user-images.githubusercontent.com/45069029/210365804-e536cc6a-d674-47d9-ada3-a9bf60353258.png)

CSV file, from left to right

- DateTime of creating the audit
- Round ID
- Outpoint
- Address
- Did we ban it or not (boolean)
- Amount
- Reason
- Details (can be null (None), flagIDs and risk categories will be there)